### PR TITLE
Allow DM to just cancel a session

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,6 @@ try:
     campaign_name = bot_config["campaign"]["name"] or "D&D"
     campaign_alias = bot_config["campaign"]["alias"] or campaign_name
     discord_vc = bot_config["discord"]["vc"]
-
 except KeyError:
     # Fall back to environment variables
     from os import environ
@@ -250,6 +249,22 @@ async def list(ctx: Context):
     )
 
 
+@bot.command()
+async def cancel(ctx: Context):
+    guild_id = ctx.guild.id
+    player_id = ctx.author.id
+
+    # If player calling command isn't DM, then tell them so and return
+    if not tracker.is_player_dm(guild_id, player_id):
+        await ctx.message.reply(f"Sorry this is a DM-only command. Have the DM run this instead")
+        return
+
+    was_cancelled = tracker.cancel_session(guild_id)
+    if was_cancelled:
+        ctx.message.channel.send(f"The upcoming session has been cancelled!")
+    else:
+        ctx.message.reply(f"Ran into an error cancelling the session. Please try again")
+
 # Support rsvp [accept|decline]
 @bot.group()
 async def rsvp(ctx: Context):
@@ -321,7 +336,7 @@ async def vote(ctx: Context):
 
 
 @vote.command(name="cancel")
-async def _cancel(ctx: Context):
+async def _vote_cancel(ctx: Context):
     tracker.add_canceller_for_guild(ctx.guild.id, ctx.author)
     await ctx.message.channel.send(
         embed=Embed().from_dict(
@@ -379,24 +394,37 @@ async def alert_dispatcher(force=False):
 
     # Check if all players have registered for the upcoming session (on the first day)
     for config in tracker.get_first_alert_configs(today):
+        guild_id = config["guild"]
+        if tracker.is_session_cancelled(guild_id):
+            logging.debug(f"Next session was cancelled! Won't alert")
+            await bt.cancel_alert_msg(config)
+            return
+
         if not tracker.is_full_group(config["guild"]):
             logging.debug("Group is not full")
             unanswered = tracker.get_unanswered_players(guild_id=config["guild"])
             await bt.first_alert(config, unanswered)
-
+            return
     # Check if all players have registered for the upcoming session (but on the second day)
     for config in tracker.get_second_alert_configs(today):
+        guild_id = config["guild"]
+        if tracker.is_session_cancelled(guild_id):
+            logging.debug(f"Next session was cancelled! Won't alert")
+            await bt.cancel_alert_msg(config)
+            return
+
         if not tracker.is_full_group(config["guild"]):
             unanswered = tracker.get_unanswered_players(guild_id=config["guild"])
             await bt.second_alert(config, unanswered)
+            return
 
     # DM the GM the accept/reject rsvp list
     for config in tracker.get_session_day_configs(today):
         await bt.send_dm(config, tracker)
-    # Reset rsvp list
+
+    # Reset rsvp list and session cancel flag
     for config in tracker.get_session_day_configs(day_before):
         bt.reset(config, tracker)
-
 
 if __name__ == "__main__":
     try:

--- a/helpers.py
+++ b/helpers.py
@@ -15,6 +15,7 @@ class Collections(str, Enum):
     INVENTORIES = "inventories"
     CONFIG = "config"
     PLAYERS = "players"
+    CANCEL_SESSION = "cancel-session"
 
 
 @unique

--- a/mongo_tracker.py
+++ b/mongo_tracker.py
@@ -1,4 +1,5 @@
 from discord import Member
+from pymongo.results import UpdateResult
 
 from helpers import Collections
 
@@ -11,6 +12,7 @@ class Tracker:
         self.inventories = db[Collections.INVENTORIES]
         self.config = db[Collections.CONFIG]
         self.players = db[Collections.PLAYERS]
+        self.cancel_flag = db[Collections.CANCEL_SESSION]
 
     @staticmethod
     def _get_user(user):
@@ -63,17 +65,55 @@ class Tracker:
             return None
 
     def get_dm(self, guild_id):
-        pass
+        try:
+            guild_config: dict = self.get_config_for_guild(guild_id)
+            return guild_config["session-dm"]["id"]
+        except Exception:
+            return None
+
+    def get_session_cancel_flag(self, guild_id: int):
+        try:
+            return self.config.find_one(
+                {"guild": guild_id}, {Collections.CANCEL_SESSION: 1, "_id": 0}
+            )[Collections.CANCEL_SESSION]
+        except Exception:
+            return None
 
     def reset(self, guild_id):
         query = {"guild": guild_id}
         self.attendees.delete_one(query)
         self.decliners.delete_one(query)
         self.cancellers.delete_one(query)
+        self.reset_cancel_flag(guild_id)
 
     def skip(self, guild_id):
         query = {"guild": guild_id}
         self.db.config.update_one({query}, {"config.alerts": False})
+
+    def cancel_session(self, guild_id: int) -> bool:
+        res: UpdateResult = self.cancel_flag.update_one(
+            {"guild": guild_id},
+            {
+                "$set": {
+                    "config": {"cancel-session": True}
+                }
+            },
+            upsert=True
+        )
+        return True if res.acknowledged else False
+
+    def reset_cancel_flag(self, guild_id: int) -> bool:
+        res = self.cancel_flag.update_one(
+            {"guild": guild_id},
+            {
+                "$set": {
+                    "config": {"cancel-session": False}
+                }
+            },
+            upsert=True
+        )
+
+        return True if res.acknowledged else False
 
     def add_attendee_for_guild(self, guild_id, attendee):
         return self.attendees.update_one(
@@ -133,6 +173,7 @@ class Tracker:
             meeting_room: int,
             first_alert: str,
             second_alert: str,
+            cancel_session: bool = False
     ):
         return self.config.update_one(
             {"guild": guild_id},
@@ -148,6 +189,7 @@ class Tracker:
                         "first-alert": first_alert,
                         "second-alert": second_alert,
                         "alerts": True,
+                        "cancel-session": cancel_session
                     },
                 }
             },
@@ -204,9 +246,16 @@ class Tracker:
         # check if attendees contains all elements of players
         return all(elem in attendees for elem in players)
 
-    def is_registered_player(self, guild_id: int, player):
+    def is_registered_player(self, guild_id: int, player) -> bool:
         players = self.get_players_for_guild(guild_id)
         return self._get_user(player) in players
+
+    def is_player_dm(self, guild_id: int, player_id: int) -> bool:
+        guild_dm_id = self.get_dm(guild_id)
+        return True if player_id == guild_dm_id else False
+
+    def is_session_cancelled(self, guild_id: int) -> bool:
+        is_cancelled = self.get
 
     def get_unanswered_players(self, guild_id: int):
         players = {player["id"]: player["name"] for player in self.get_players_for_guild(guild_id)}

--- a/tasks.py
+++ b/tasks.py
@@ -30,6 +30,10 @@ class BotTasks:
             f"Game tonight! Please RSVP: `{self.bot.command_prefix}rsvp accept` or `{self.bot.command_prefix}rsvp decline`."
         )
 
+    async def cancel_alert_msg(self, config) -> None:
+        channel: Any = await self.bot.fetch_channel(config["config"]["meeting-room"])
+        await channel.send(f"Reminder, the upcoming session was cancelled!")
+
     async def send_dm(self, config, tracker) -> None:
         dm: Any = await self.bot.fetch_user(config["config"]["session-dm"]["id"])
         if dm is None:


### PR DESCRIPTION
Sometimes we don't need all players to vote to skip a session. A DM should just be able to cancel the session regardless of if players choose to accept or decline 

![image](https://user-images.githubusercontent.com/4042877/213937023-d4f4ca64-dc40-442b-a31d-1cfabee142bd.png)
